### PR TITLE
Expose fire effect in playground catalog

### DIFF
--- a/tools/js-effects/apps/playground/src/App.tsx
+++ b/tools/js-effects/apps/playground/src/App.tsx
@@ -54,6 +54,19 @@ const effectControls: Record<string, OptionConfig[]> = {
     { key: "maxStainRadius", label: "Max Pool Radius", step: 1 },
     { key: "drag", label: "Drag", step: 0.01 },
   ],
+  fire: [
+    { key: "spawnInterval", label: "Spawn Interval (s)", step: 0.01 },
+    { key: "embersPerBurst", label: "Embers per Burst", step: 1 },
+    { key: "flamesPerBurst", label: "Flames per Burst", step: 1 },
+    { key: "riseSpeed", label: "Rise Speed", step: 1 },
+    { key: "windX", label: "Wind X", step: 0.5 },
+    { key: "swirl", label: "Swirl", step: 0.5 },
+    { key: "jitter", label: "Jitter", step: 0.5 },
+    { key: "sizeScale", label: "Size Scale", step: 0.1 },
+    { key: "lifeScale", label: "Life Scale", step: 0.1 },
+    { key: "gradientBias", label: "Gradient Bias", step: 0.05 },
+    { key: "emberAlpha", label: "Ember Alpha", step: 0.05 },
+  ],
 };
 
 const isCanvasTexture = (value: unknown): value is HTMLCanvasElement =>

--- a/tools/js-effects/apps/playground/src/effects.ts
+++ b/tools/js-effects/apps/playground/src/effects.ts
@@ -1,5 +1,6 @@
 import {
   BloodSplatterDefinition,
+  FireEffectDefinition,
   ImpactBurstDefinition,
   MeleeSwingEffectDefinition,
   PlaceholderAuraDefinition,
@@ -31,6 +32,14 @@ export const availableEffects: AnyEffectCatalogEntry[] = [
       "The red melee hitbox used in-game; fades quickly after spawning.",
     definition: MeleeSwingEffectDefinition,
     definitionName: "MeleeSwingEffectDefinition",
+  },
+  {
+    id: FireEffectDefinition.type,
+    name: "Fire",
+    description:
+      "A looping campfire with swirling embers and tongues of flame.",
+    definition: FireEffectDefinition,
+    definitionName: "FireEffectDefinition",
   },
   {
     id: ImpactBurstDefinition.type,


### PR DESCRIPTION
## Summary
- add the fire effect to the playground catalog so it can be previewed
- expose numeric controls for adjusting the fire effect options

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e53d2ca79c832f9964985b6ca62e4e