### PR TITLE
Add burning visuals and ignite fireball hits

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -17,6 +17,7 @@ The condition system powers persistent gameplay states (burning, poison, frozen,
 
 ## Burning example
 - Lava hazards call `applyCondition` with `ConditionBurning` when an actor overlaps the obstacle.
+- Fireball impacts also call `applyCondition` so direct hits ignite the target before the lava timer kicks in.
 - The `OnApply` hook spawns a looping `fire` effect that follows the actor and refreshes while the condition is active.
 - Every `200ms` the `OnTick` handler spawns a `burning-tick` effect that uses `healthDeltaBehavior` to deduct health, so the damage path reuses the existing effect behaviours.
 - After three seconds without refresh, `OnExpire` cleans up the attached fire effect and the actor stops taking damage.

--- a/server/effects.go
+++ b/server/effects.go
@@ -180,7 +180,7 @@ func newProjectileTemplates() map[string]*ProjectileTemplate {
 func newEffectBehaviors() map[string]effectBehavior {
 	return map[string]effectBehavior{
 		effectTypeAttack:      healthDeltaBehavior("healthDelta", 0),
-		effectTypeFireball:    healthDeltaBehavior("healthDelta", 0),
+		effectTypeFireball:    damageAndConditionBehavior("healthDelta", 0, ConditionBurning),
 		effectTypeBurningTick: healthDeltaBehavior("healthDelta", 0),
 	}
 }
@@ -201,6 +201,23 @@ func healthDeltaBehavior(param string, fallback float64) effectBehavior {
 				log.Printf("%s defeated %s with %s", eff.Owner, target.ID, eff.Type)
 			}
 		}
+	})
+}
+
+func damageAndConditionBehavior(param string, fallback float64, condition ConditionType) effectBehavior {
+	base := healthDeltaBehavior(param, fallback)
+	return effectBehaviorFunc(func(w *World, eff *effectState, target *actorState, now time.Time) {
+		if base != nil {
+			base.OnHit(w, eff, target, now)
+		}
+		if w == nil || target == nil || condition == "" {
+			return
+		}
+		source := ""
+		if eff != nil {
+			source = eff.Owner
+		}
+		w.applyCondition(target, condition, source, now)
 	})
 }
 

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -879,10 +879,14 @@ func TestFireballDealsDamageOnHit(t *testing.T) {
 		hub.mu.Unlock()
 		t.Fatalf("expected target to remain in hub")
 	}
-	expected := playerMaxHealth - fireballDamage
+	expected := playerMaxHealth - fireballDamage - lavaDamagePerSecond*burningTickInterval.Seconds()
 	if math.Abs(target.Health-expected) > 1e-6 {
 		hub.mu.Unlock()
 		t.Fatalf("expected target health %.1f, got %.1f", expected, target.Health)
+	}
+	if target.conditions == nil || target.conditions[ConditionBurning] == nil {
+		hub.mu.Unlock()
+		t.Fatalf("expected fireball hit to apply burning condition")
 	}
 	hub.mu.Unlock()
 }


### PR DESCRIPTION
## Summary
- spawn the FireEffectDefinition around actors with the burning condition so the client shows embers that follow targets
- apply the burning condition when fireballs strike and share the helper between damage and condition application
- document the new fireball ignition behavior and update the fireball test expectation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e54c0359cc832fb6d159317412595a