### PR TITLE
docs: expand npc ai system overview

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -1,51 +1,109 @@
-# AI System Overview
+# NPC AI System
 
-The Mine & Die server drives all non-player characters through deterministic finite state machines (FSMs). Behaviour is authored in JSON (`server/ai_configs/`) and compiled at startup into compact ID-based tables so the tick loop avoids string comparisons and reflection.
+Mine & Die drives every non-player character (NPC) from deterministic finite state machines (FSMs). Behaviour is authored in JSON under `server/ai_configs/`, compiled at startup into ID-based tables, and evaluated every simulation tick inside `World.runAI`. The executor only emits standard commands (`CommandMove`, `CommandAction`, etc.), so gameplay rules continue to flow through the core simulation systems.
 
-## Authoring Configs
+## Asset pipeline
 
-Each config targets a single NPC archetype and contains:
+1. JSON configs are embedded at build time (`//go:embed ai_configs/*.json`).
+2. `loadAILibrary` deserialises each file, validates references, and calls `compileAIConfig` to translate author-friendly names into compact enums and parameter slices (`ai_library.go`).
+3. Each compiled config receives a monotonically increasing ID and is stored both by NPC type and by ID for quick lookup during runtime.
+4. When NPCs spawn, their `AIConfigID`, initial state, and blackboard defaults are fetched from the shared library (`ai_library.go`, `npc.go`).
 
-- `npc_type` – The canonical NPC type string (e.g. `"goblin"`).
-- `states[]` – An ordered list of states with `id`, optional `tick_every`, `duration_ticks`, `actions[]`, and `transitions[]`.
-- `blackboard_defaults` – Optional defaults for fields like `arrive_radius`, `pause_ticks`, or `stuck_epsilon`.
+This compilation step removes string comparisons and reflection from the hot path—every action, condition, and ability is resolved to an integer ID before the simulation starts.
 
-States reference declarative actions and conditions from the shared library:
+## Authoring configs
 
-- **Actions** (`actions[]`) enqueue commands or tweak blackboard data without mutating world state. Examples include `moveToward`, `stop`, `setTimer`, `setWaypoint`, `setRandomDestination` for free-roam targets, `moveAway` to flee from a threat, and `useAbility`.
-- **Transitions** (`transitions[]`) evaluate conditions in order (`reachedWaypoint`, `timerExpired`, `playerWithin`, `nonRatWithin`, `stuck`, etc.). The first condition that returns true selects the next state.
+Each config targets one archetype and contains:
 
-Configs are embedded at build time and compiled by `server/ai_library.go` into typed slices that map names → small enums and parameter blocks. This step validates references and prevents runtime string work.
+- `npc_type` – Matches the `NPCType` string used when seeding NPCs (`NPCTypeGoblin`, `NPCTypeRat`, etc.).
+- `blackboard_defaults` – Optional defaults applied on spawn. Supported fields are `waypoint_index`, `arrive_radius`, `pause_ticks`, `patrol_speed`, and `stuck_epsilon`. These become the baseline values for the runtime blackboard (`ai_library.go`).
+- `states[]` – Ordered list of states. The array index doubles as the numeric state ID used at runtime.
+  - `id` – Human-readable name used in configs/tests.
+  - `tick_every` – Cadence (in ticks) between evaluations. `0` forces evaluation next tick.
+  - `duration_ticks` – Optional enter timer that blocks transitions until the delay expires.
+  - `actions[]` – Declarative actions executed in order whenever the state runs.
+  - `transitions[]` – Ordered conditions. The first condition that returns `true` selects the next state.
 
-## Runtime Execution
+### Actions
 
-The executor in `server/ai_executor.go` runs during the AI phase of each tick:
+`compileAIConfig` currently recognises the following actions (`ai_library.go`):
 
-1. NPC IDs are sorted to keep decision order deterministic.
-2. The executor skips actors whose `NextDecisionAt` lies in the future, capping total decisions per tick.
-3. Transitions are evaluated, updating the active state when IDs change.
-4. Actions execute. Ability usage still enqueues `CommandAction` payloads, while movement actions plan path targets that the simulation's path follower resolves into per-tick intents.
-5. Blackboard bookkeeping updates waypoints, timers, `StuckCounter`, and schedules the next decision tick.
+| Action | Purpose | Key parameters |
+| ------ | ------- | -------------- |
+| `moveToward` | Request navigation toward a waypoint, the tracked player target, or an offset vector. | `target` (`waypoint`/`player`/`vector`), optional `vector` payload. |
+| `stop` | Clears any active path and emits a zeroed movement command so the NPC halts immediately. | – |
+| `useAbility` | Queues a `CommandAction` for the mapped ability and starts its cooldown. | `ability` (matches effect names such as `attack`, `fireball`). |
+| `face` | Rotates the NPC to look toward the current waypoint or tracked player without moving. | `target` (same options as `moveToward`). |
+| `setTimer` | On state entry, schedules `WaitUntil = now + duration` for later `timerExpired` checks. | `duration_ticks`. Defaults to `pause_ticks` when omitted. |
+| `setWaypoint` | On state entry, either advance to the next waypoint or jump to a specific index. | `advance` flag or explicit `waypoint`. |
+| `setRandomDestination` | Picks a roam point around the NPC’s `Home` vector and seeds a navigation request. | `radius`, optional `min_radius`. |
+| `moveAway` | Plans a path away from the stored `TargetActorID`, respecting minimum/maximum flee distance. | `distance`, optional `min_distance`. |
 
-`moveToward` actions build A* paths across a coarse navigation grid. If a direct path cannot be found the planner probes nearby tiles and selects the closest accessible fallback. Path progress is monitored each tick so pushes or external nudges trigger a replanning cooldown before the NPC resumes travel.
+All actions only mutate the blackboard or enqueue commands; world state changes still happen in the simulation step.
 
-Because actions only enqueue commands, the simulation loop remains the single authority for world mutations.
+### Transitions
 
-## Goblin Patrol Example
+Transition conditions are parsed into integer IDs with optional parameter blocks (`ai_library.go`):
 
-`server/ai_configs/goblin.json` defines a two-state patrol:
+| Condition | Behaviour |
+| --------- | --------- |
+| `reachedWaypoint` | Succeeds when the NPC is within `ArriveRadius` (overridable per transition) of the active waypoint, with stall-sensitive relaxation to avoid getting stuck (`ai_executor.go`). |
+| `timerExpired` | Checks if the state entry timer (`WaitUntil`) has elapsed. |
+| `playerWithin` | Locks onto the closest player within the supplied radius and stores their ID on the blackboard. |
+| `nonRatWithin` | Similar to `playerWithin` but excludes rats and the NPC itself; used by the rat behaviour. |
+| `lostSight` | Returns `true` when the tracked target drifts beyond a distance threshold or disappears. |
+| `cooldownReady` | Gates state changes on ability cooldown availability. |
+| `stuck` | Fires if the NPC’s recent movement fell below `epsilon` for `decisions` consecutive evaluations, signalling a stalled path. |
 
-- `Patrol` runs every 5 ticks, issues `moveToward(waypoint)`, and transitions to `Wait` when within `arrive_radius`.
-- `Wait` executes every tick, calls `stop()`, sets a timer for `pause_ticks`, advances the waypoint index once on entry, and returns to `Patrol` when the timer expires.
+Conditions run in the order declared in the JSON, so place higher-priority transitions first.
 
-The defaults seed goblins with two waypoints, pause for half a second (~30 ticks), and detect stuck behaviour using a small epsilon. Adding new archetypes follows the same pattern—extend the JSON, cover it with table-driven tests, and the executor requires no modifications.
+## Runtime execution
 
-## Rat Wander & Flee Example
+`World.runAI` (invoked from the main tick loop) evaluates up to 64 NPCs per tick to keep frame times predictable (`ai_executor.go`). The flow is:
 
-`server/ai_configs/rat.json` shows how lightweight behaviours can mix the new actions and conditions:
+1. Gather and lexicographically sort NPC IDs to maintain deterministic iteration.
+2. Skip NPCs whose next decision tick (`NextDecisionAt`) lies in the future or whose config/state table is missing.
+3. Clamp the current state index and fall back to the initial state if the stored value is invalid.
+4. Walk the state’s transitions in order, using `evaluateCondition` helpers. Matching a new state resets `StateEnteredTick`, applies any `enterTimer`, and keeps evaluation within the freshly selected state.
+5. Execute the state’s actions. Movement-related actions call into navigation helpers to (re)build paths, while ability usage emits a `CommandAction` using `abilityIDToCommand` and stamps the corresponding cooldown.
+6. Schedule the next decision tick based on the state cadence and record bookkeeping timestamps. The blackboard is then updated with positional deltas and waypoint progress.
 
-- `Wander` runs every few ticks, calls `setRandomDestination` to pick a roam point near the rat's den, and schedules a timer so the same state re-evaluates periodically.
-- `Pause` clears movement for a short breather while still watching for nearby non-rat actors via `nonRatWithin`.
-- `Flee` fires when players or hostile NPCs get close. `moveAway` recalculates paths away from the stored threat each cadence until `lostSight` or a timer returns the rat to calmer states.
+Because commands are enqueued rather than applied immediately, the simulation step remains the single authority for collision resolution, damage, and effect lifecycles.
 
-The config keeps the behaviour deterministic—random choices draw from the world's seeded RNG—so regression tests can assert both wandering and scurry responses.
+## Movement planning and blackboard maintenance
+
+Navigation uses a coarse grid planner shared with players (`npc_path.go`):
+
+- `ensureNPCPath` builds an A* path toward the desired target and stores it on the blackboard, retrying with relaxed targets when necessary. Failed plans impose a short cooldown before the next attempt.
+- `followNPCPath` is called each tick to advance along the stored path. It updates facing, intent vectors, and triggers replans when the NPC stops making progress (pushed by other actors, blocked by obstacles, etc.).
+- `updateBlackboard` tracks per-waypoint distance, the best progress achieved so far, and stall counters. If progress stagnates, `reachedWaypoint` gradually relaxes the acceptable radius so patrols keep moving even when geometry interferes (`ai_executor.go`).
+- Separate fields (`PathLastDistance`, `PathStallTicks`, `PathRecalcTick`) prevent thrashing by delaying replans until meaningful time has passed.
+
+## Ability and timer management
+
+Abilities are mapped from config strings to internal IDs during compilation. When `useAbility` runs, the executor:
+
+1. Emits a `CommandAction` for the configured ability name (`attack`, `fireball`, etc.).
+2. Uses `abilityCooldownTicks` to convert cooldown durations into simulation ticks and records `nextAbilityReady[ability]` on the blackboard (`ai_executor.go`).
+3. Later transitions can query `cooldownReady` to branch into follow-up states only when the ability is available again.
+
+Timers set via `setTimer` (or defaults) populate `WaitUntil`. The `timerExpired` condition and the `enterTimer` field give designers two timing tools: one for general-purpose waits and another for a guaranteed dwell time immediately after entering a state.
+
+## Existing behaviours
+
+Two configs ship by default (`server/ai_configs/`):
+
+- **Goblin patrol** – Alternates between `Patrol` and `Wait`, marching through fixed waypoints. Reached-waypoint detection uses stall-aware radius relaxation so the patrol resumes even when nudged off path.
+- **Rat wander & flee** – Roams around its home point, pauses periodically, and switches into a `Flee` state when players or hostile NPCs enter the configured radius. `moveAway` keeps rats backing off until `lostSight` or timers allow calmer behaviour.
+
+Both behaviours are covered by regression tests in `server/ai_test.go`, which simulate hundreds of ticks to validate patrol loops, stall recovery, and flee logic.
+
+## Extending the system
+
+To add a new archetype:
+
+1. Author a JSON config describing states, actions, and transitions.
+2. Add regression coverage in `server/ai_test.go` so deterministic patrols/flee/ability usage stay protected.
+3. Update documentation if new actions or conditions are introduced.
+
+The executor and planner are already resilient to multiple NPC types—new behaviours typically require only config and test updates.


### PR DESCRIPTION
## Summary
- expand the NPC AI documentation with details on the config pipeline, runtime executor, and available actions/conditions
- document navigation, blackboard maintenance, and ability cooldown handling for authors adding new behaviours

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e5e6668e3c832fb89a9b80533395d7