### PR TITLE
Add structured server logging pipeline

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,62 @@
+# Server Logging System
+
+The server exposes a structured logging pipeline that decouples simulation code from concrete output sinks.
+
+## Architecture Overview
+
+```text
+[Simulation] → Publish(Event) → Router → Sinks
+```
+
+* **Publishers** live next to gameplay logic. They construct `logging.Event` instances and call `Publish` on the injected publisher.
+* **Router** owns a bounded queue, enriches events with wall-clock timestamps, and fans the events out to enabled sinks asynchronously. It drops new events when the buffer is full and records a counter for observability.
+* **Sinks** render events to a destination. The initial implementation ships with:
+  * Console sink – parity with `log.Printf` style output.
+  * JSON sink – newline-delimited structured events.
+  * Memory sink – in-memory collector for unit/integration tests.
+
+## Event Schema
+
+Events share a common envelope via `logging.Event`:
+
+| Field     | Description                                                      |
+|-----------|------------------------------------------------------------------|
+| `Type`    | Namespaced event type (e.g. `combat.attack_overlap`).             |
+| `Tick`    | Simulation tick that triggered the event.                        |
+| `Time`    | Wall clock timestamp populated by the router.                    |
+| `Actor`   | Primary entity reference (`ID`, `Kind`).                         |
+| `Targets` | Optional additional entities affected by the event.              |
+| `Severity`| Severity hint (`debug`, `info`, `warn`, `error`).                 |
+| `Category`| High-level subsystem key (combat, gameplay, system, …).          |
+| `Payload` | Domain specific struct with deterministic fields.                |
+| `Extra`   | Map for additive metadata attached by `WithFields`.              |
+
+### Combat Events
+
+| Event Type              | Payload                                   |
+|-------------------------|-------------------------------------------|
+| `combat.attack_overlap` | `ability`, `playerTargets`, `npcTargets`. |
+
+The payload structure is defined in `server/logging/combat/attack.go`.
+
+## Configuration
+
+`logging.Config` controls router behaviour:
+
+* `EnabledSinks` – list of sink identifiers to activate (`console`, `json`, `memory`).
+* `BufferSize` – router channel capacity before events are dropped.
+* `MinimumSeverity` – lower bound for forwarded events.
+* `DropWarnInterval` – throttle interval for overflow warnings.
+* `Fields` – contextual metadata automatically merged into `Event.Extra`.
+* `JSON` and `Console` nested structs hold sink-specific options.
+
+`logging.DefaultConfig()` mirrors the previous stdout behaviour by enabling only the console sink.
+
+## Testing Support
+
+The memory sink (`sinks.NewMemorySink`) stores events in-process and exposes `Events()`/`Reset()` helpers so tests can assert on emitted sequences.
+
+## Shutdown
+
+`Router.Close(ctx)` flushes the queue, waits for sink goroutines, and closes each sink with the provided context. The server defers this during shutdown to ensure no telemetry is lost.
+

--- a/server/logging/combat/attack.go
+++ b/server/logging/combat/attack.go
@@ -1,0 +1,45 @@
+package combat
+
+import (
+	"context"
+
+	"mine-and-die/server/logging"
+)
+
+const AttackOverlapEventType logging.EventType = "combat.attack_overlap"
+
+type AttackOverlapPayload struct {
+	Ability       string              `json:"ability"`
+	PlayerTargets []logging.EntityRef `json:"playerTargets,omitempty"`
+	NPCTargets    []logging.EntityRef `json:"npcTargets,omitempty"`
+}
+
+func AttackOverlap(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, ability string, players []logging.EntityRef, npcs []logging.EntityRef) {
+	if pub == nil {
+		return
+	}
+	targets := make([]logging.EntityRef, 0, len(players)+len(npcs))
+	targets = append(targets, players...)
+	targets = append(targets, npcs...)
+	payload := AttackOverlapPayload{
+		Ability:       ability,
+		PlayerTargets: nil,
+		NPCTargets:    nil,
+	}
+	if len(players) > 0 {
+		payload.PlayerTargets = append([]logging.EntityRef(nil), players...)
+	}
+	if len(npcs) > 0 {
+		payload.NPCTargets = append([]logging.EntityRef(nil), npcs...)
+	}
+	event := logging.Event{
+		Type:     AttackOverlapEventType,
+		Tick:     tick,
+		Actor:    actor,
+		Targets:  targets,
+		Severity: logging.SeverityInfo,
+		Category: logging.CategoryCombat,
+		Payload:  payload,
+	}
+	pub.Publish(ctx, event)
+}

--- a/server/logging/config.go
+++ b/server/logging/config.go
@@ -1,0 +1,56 @@
+package logging
+
+import "time"
+
+type Config struct {
+	EnabledSinks     []string
+	BufferSize       int
+	MinimumSeverity  Severity
+	Fields           map[string]any
+	JSON             JSONConfig
+	Console          ConsoleConfig
+	DropWarnInterval time.Duration
+}
+
+type JSONConfig struct {
+	FilePath      string
+	MaxBatch      int
+	FlushInterval time.Duration
+}
+
+type ConsoleConfig struct {
+	UseColor bool
+}
+
+func DefaultConfig() Config {
+	return Config{
+		EnabledSinks:     []string{"console"},
+		BufferSize:       512,
+		MinimumSeverity:  SeverityInfo,
+		DropWarnInterval: 5 * time.Second,
+		JSON: JSONConfig{
+			MaxBatch:      32,
+			FlushInterval: 2 * time.Second,
+		},
+	}
+}
+
+func (c Config) HasSink(name string) bool {
+	for _, s := range c.EnabledSinks {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Config) CloneFields() map[string]any {
+	if len(c.Fields) == 0 {
+		return nil
+	}
+	cloned := make(map[string]any, len(c.Fields))
+	for k, v := range c.Fields {
+		cloned[k] = v
+	}
+	return cloned
+}

--- a/server/logging/publisher.go
+++ b/server/logging/publisher.go
@@ -1,0 +1,133 @@
+package logging
+
+import (
+	"context"
+	"time"
+)
+
+type EventType string
+
+type Severity int
+
+const (
+	SeverityDebug Severity = iota
+	SeverityInfo
+	SeverityWarn
+	SeverityError
+)
+
+type EntityKind string
+
+const (
+	EntityKindUnknown EntityKind = "unknown"
+	EntityKindPlayer  EntityKind = "player"
+	EntityKindNPC     EntityKind = "npc"
+	EntityKindEffect  EntityKind = "effect"
+	EntityKindWorld   EntityKind = "world"
+)
+
+type Event struct {
+	Type      EventType      `json:"type"`
+	Tick      uint64         `json:"tick"`
+	Time      time.Time      `json:"time"`
+	Actor     EntityRef      `json:"actor"`
+	Targets   []EntityRef    `json:"targets,omitempty"`
+	Severity  Severity       `json:"severity"`
+	Category  string         `json:"category,omitempty"`
+	Payload   any            `json:"payload,omitempty"`
+	Extra     map[string]any `json:"extra,omitempty"`
+	TraceID   string         `json:"traceId,omitempty"`
+	CommandID string         `json:"commandId,omitempty"`
+}
+
+type EntityRef struct {
+	ID   string     `json:"id"`
+	Kind EntityKind `json:"kind"`
+}
+
+const (
+	CategoryGameplay = "gameplay"
+	CategoryCombat   = "combat"
+	CategorySystem   = "system"
+)
+
+type Publisher interface {
+	Publish(ctx context.Context, event Event)
+}
+
+type PublisherFunc func(ctx context.Context, event Event)
+
+func (f PublisherFunc) Publish(ctx context.Context, event Event) {
+	if f == nil {
+		return
+	}
+	f(ctx, event)
+}
+
+type nopPublisher struct{}
+
+func (nopPublisher) Publish(context.Context, Event) {}
+
+func NopPublisher() Publisher {
+	return nopPublisher{}
+}
+
+type fieldPublisher struct {
+	next   Publisher
+	fields map[string]any
+}
+
+func (p *fieldPublisher) Publish(ctx context.Context, event Event) {
+	if p.next == nil {
+		return
+	}
+	if len(p.fields) > 0 {
+		event = cloneForFields(event)
+		if event.Extra == nil {
+			event.Extra = make(map[string]any, len(p.fields))
+		}
+		for k, v := range p.fields {
+			if _, exists := event.Extra[k]; !exists {
+				event.Extra[k] = v
+			}
+		}
+	}
+	p.next.Publish(ctx, event)
+}
+
+func cloneForFields(event Event) Event {
+	cloned := event
+	if len(event.Targets) > 0 {
+		cloned.Targets = append([]EntityRef(nil), event.Targets...)
+	}
+	if event.Extra != nil {
+		copied := make(map[string]any, len(event.Extra))
+		for k, v := range event.Extra {
+			copied[k] = v
+		}
+		cloned.Extra = copied
+	}
+	return cloned
+}
+
+func WithFields(p Publisher, fields map[string]any) Publisher {
+	if p == nil {
+		return NopPublisher()
+	}
+	if len(fields) == 0 {
+		return p
+	}
+	copied := make(map[string]any, len(fields))
+	for k, v := range fields {
+		copied[k] = v
+	}
+	return &fieldPublisher{next: p, fields: copied}
+}
+
+func (e Event) WithExtra(key string, value any) Event {
+	if e.Extra == nil {
+		e.Extra = make(map[string]any, 1)
+	}
+	e.Extra[key] = value
+	return e
+}

--- a/server/logging/router.go
+++ b/server/logging/router.go
@@ -1,0 +1,306 @@
+package logging
+
+import (
+	"context"
+	"log"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Clock interface {
+	Now() time.Time
+}
+
+type ClockFunc func() time.Time
+
+func (f ClockFunc) Now() time.Time {
+	return f()
+}
+
+type Sink interface {
+	Write(Event) error
+	Close(context.Context) error
+}
+
+type NamedSink struct {
+	Name string
+	Sink Sink
+}
+
+type Router struct {
+	cfg          Config
+	queue        chan Event
+	sinks        []*sinkWorker
+	clock        Clock
+	fallback     *log.Logger
+	ctx          context.Context
+	cancel       context.CancelFunc
+	closed       atomic.Bool
+	minSeverity  Severity
+	fields       map[string]any
+	wg           sync.WaitGroup
+	dispatchOnce sync.Once
+
+	eventsTotal  atomic.Uint64
+	droppedTotal atomic.Uint64
+	lastDropLog  atomic.Int64
+}
+
+type RouterStats struct {
+	EventsTotal  uint64
+	DroppedTotal uint64
+}
+
+func NewRouter(clock Clock, cfg Config, namedSinks []NamedSink) (*Router, error) {
+	if clock == nil {
+		clock = ClockFunc(time.Now)
+	}
+	bufferSize := cfg.BufferSize
+	if bufferSize <= 0 {
+		bufferSize = 512
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &Router{
+		cfg:         cfg,
+		queue:       make(chan Event, bufferSize),
+		clock:       clock,
+		fallback:    log.New(os.Stderr, "[logging] ", log.LstdFlags),
+		ctx:         ctx,
+		cancel:      cancel,
+		minSeverity: cfg.MinimumSeverity,
+		fields:      cfg.CloneFields(),
+	}
+
+	sinkBuffer := bufferSize
+	if sinkBuffer > 1024 {
+		sinkBuffer = 1024
+	}
+	if sinkBuffer < 32 {
+		sinkBuffer = 32
+	}
+
+	for _, named := range namedSinks {
+		if named.Sink == nil {
+			continue
+		}
+		worker := newSinkWorker(named.Name, named.Sink, sinkBuffer, r.fallback)
+		r.sinks = append(r.sinks, worker)
+	}
+
+	r.start()
+	return r, nil
+}
+
+func (r *Router) start() {
+	r.dispatchOnce.Do(func() {
+		r.wg.Add(1)
+		go func() {
+			defer func() {
+				for _, worker := range r.sinks {
+					close(worker.events)
+				}
+				r.wg.Done()
+			}()
+			for {
+				select {
+				case <-r.ctx.Done():
+					r.drain()
+					return
+				case event := <-r.queue:
+					r.forward(event)
+				}
+			}
+		}()
+
+		for _, worker := range r.sinks {
+			r.wg.Add(1)
+			go func(w *sinkWorker) {
+				defer r.wg.Done()
+				w.run()
+			}(worker)
+		}
+	})
+}
+
+func (r *Router) drain() {
+	for {
+		select {
+		case event := <-r.queue:
+			r.forward(event)
+		default:
+			return
+		}
+	}
+}
+
+func (r *Router) forward(event Event) {
+	if event.Severity < r.minSeverity {
+		return
+	}
+	if event.Time.IsZero() {
+		event.Time = r.clock.Now()
+	}
+	if len(r.fields) > 0 {
+		event = cloneForFields(event)
+		if event.Extra == nil {
+			event.Extra = make(map[string]any, len(r.fields))
+		}
+		for k, v := range r.fields {
+			if _, exists := event.Extra[k]; !exists {
+				event.Extra[k] = v
+			}
+		}
+	}
+	r.eventsTotal.Add(1)
+	for _, worker := range r.sinks {
+		worker.enqueue(event)
+	}
+}
+
+func (r *Router) Publish(ctx context.Context, event Event) {
+	if event.Type == "" {
+		return
+	}
+	if r.closed.Load() {
+		return
+	}
+	select {
+	case r.queue <- event:
+	default:
+		r.handleDrop(event)
+	}
+}
+
+func (r *Router) handleDrop(event Event) {
+	r.droppedTotal.Add(1)
+	interval := r.cfg.DropWarnInterval
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	now := time.Now().UnixNano()
+	next := r.lastDropLog.Load()
+	if next == 0 || now >= next {
+		if r.lastDropLog.CompareAndSwap(next, now+interval.Nanoseconds()) {
+			r.fallback.Printf("dropping event type=%s tick=%d", event.Type, event.Tick)
+		}
+	}
+}
+
+func (r *Router) Close(ctx context.Context) error {
+	if !r.closed.CompareAndSwap(false, true) {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	r.cancel()
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	var firstErr error
+	for _, worker := range r.sinks {
+		if err := worker.sink.Close(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (r *Router) Stats() RouterStats {
+	return RouterStats{
+		EventsTotal:  r.eventsTotal.Load(),
+		DroppedTotal: r.droppedTotal.Load(),
+	}
+}
+
+func (r *Router) Sink(name string) Sink {
+	for _, worker := range r.sinks {
+		if worker.name == name {
+			return worker.sink
+		}
+	}
+	return nil
+}
+
+type sinkWorker struct {
+	name      string
+	sink      Sink
+	events    chan Event
+	fallback  *log.Logger
+	failures  int
+	nextRetry time.Time
+}
+
+func newSinkWorker(name string, sink Sink, buffer int, fallback *log.Logger) *sinkWorker {
+	if buffer <= 0 {
+		buffer = 32
+	}
+	return &sinkWorker{
+		name:     name,
+		sink:     sink,
+		events:   make(chan Event, buffer),
+		fallback: fallback,
+	}
+}
+
+func (w *sinkWorker) enqueue(event Event) {
+	cloned := cloneForFields(event)
+	select {
+	case w.events <- cloned:
+	default:
+		w.reportDrop(event)
+	}
+}
+
+func (w *sinkWorker) run() {
+	for event := range w.events {
+		w.waitUntilReady()
+		if err := w.sink.Write(event); err != nil {
+			w.fail(err)
+		} else {
+			w.failures = 0
+			w.nextRetry = time.Time{}
+		}
+	}
+}
+
+func (w *sinkWorker) waitUntilReady() {
+	if w.failures == 0 {
+		return
+	}
+	for {
+		now := time.Now()
+		if w.nextRetry.IsZero() || now.After(w.nextRetry) || now.Equal(w.nextRetry) {
+			return
+		}
+		time.Sleep(time.Until(w.nextRetry))
+	}
+}
+
+func (w *sinkWorker) fail(err error) {
+	if err == nil {
+		return
+	}
+	w.failures++
+	delay := time.Duration(1<<min(w.failures, 5)) * time.Second
+	w.nextRetry = time.Now().Add(delay)
+	w.fallback.Printf("sink %s failed: %v (retry in %s)", w.name, err, delay)
+}
+
+func (w *sinkWorker) reportDrop(event Event) {
+	w.fallback.Printf("sink %s backlog full dropping event type=%s", w.name, event.Type)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/server/logging/sinks/console.go
+++ b/server/logging/sinks/console.go
@@ -1,0 +1,83 @@
+package sinks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"mine-and-die/server/logging"
+)
+
+type ConsoleSink struct {
+	logger *log.Logger
+}
+
+func NewConsoleSink(w io.Writer, cfg logging.ConsoleConfig) *ConsoleSink {
+	prefix := ""
+	flags := log.LstdFlags
+	return &ConsoleSink{logger: log.New(w, prefix, flags)}
+}
+
+func (s *ConsoleSink) Write(event logging.Event) error {
+	if s.logger == nil {
+		return nil
+	}
+	payload := formatPayload(event.Payload)
+	targets := formatTargets(event.Targets)
+	s.logger.Printf("[%s] tick=%d actor=%s severity=%s%s%s", event.Type, event.Tick, formatEntity(event.Actor), formatSeverity(event.Severity), targets, payload)
+	return nil
+}
+
+func (s *ConsoleSink) Close(context.Context) error {
+	return nil
+}
+
+func formatSeverity(sev logging.Severity) string {
+	switch sev {
+	case logging.SeverityDebug:
+		return "debug"
+	case logging.SeverityInfo:
+		return "info"
+	case logging.SeverityWarn:
+		return "warn"
+	case logging.SeverityError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+func formatEntity(ref logging.EntityRef) string {
+	if ref.ID == "" {
+		return string(ref.Kind)
+	}
+	if ref.Kind == "" {
+		return ref.ID
+	}
+	return fmt.Sprintf("%s:%s", ref.Kind, ref.ID)
+}
+
+func formatTargets(targets []logging.EntityRef) string {
+	if len(targets) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(targets))
+	for _, target := range targets {
+		parts = append(parts, formatEntity(target))
+	}
+	return fmt.Sprintf(" targets=%s", strings.Join(parts, ","))
+}
+
+func formatPayload(payload any) string {
+	if payload == nil {
+		return ""
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Sprintf(" payload=%v", payload)
+	}
+	return fmt.Sprintf(" payload=%s", data)
+}

--- a/server/logging/sinks/json.go
+++ b/server/logging/sinks/json.go
@@ -1,0 +1,131 @@
+package sinks
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"sync"
+	"time"
+
+	"mine-and-die/server/logging"
+)
+
+type JSONSink struct {
+	mu       sync.Mutex
+	writer   *bufio.Writer
+	file     *os.File
+	cfg      logging.JSONConfig
+	buffer   []logging.Event
+	ticker   *time.Ticker
+	shutdown chan struct{}
+}
+
+func NewJSONSink(cfg logging.JSONConfig) (*JSONSink, error) {
+	if cfg.FilePath == "" {
+		cfg.FilePath = "events.jsonl"
+	}
+	file, err := os.OpenFile(cfg.FilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	maxBatch := cfg.MaxBatch
+	if maxBatch <= 0 {
+		maxBatch = 32
+	}
+	flushInterval := cfg.FlushInterval
+	if flushInterval <= 0 {
+		flushInterval = 2 * time.Second
+	}
+	sink := &JSONSink{
+		writer:   bufio.NewWriter(file),
+		file:     file,
+		cfg:      cfg,
+		buffer:   make([]logging.Event, 0, maxBatch),
+		ticker:   time.NewTicker(flushInterval),
+		shutdown: make(chan struct{}),
+	}
+	go sink.loop()
+	return sink, nil
+}
+
+func (s *JSONSink) loop() {
+	for {
+		select {
+		case <-s.ticker.C:
+			s.Flush()
+		case <-s.shutdown:
+			return
+		}
+	}
+}
+
+func (s *JSONSink) Write(event logging.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.buffer = append(s.buffer, cloneForJSON(event))
+	if len(s.buffer) >= cap(s.buffer) {
+		return s.flushLocked()
+	}
+	return nil
+}
+
+func (s *JSONSink) Flush() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.flushLocked()
+}
+
+func (s *JSONSink) flushLocked() error {
+	if len(s.buffer) == 0 {
+		return nil
+	}
+	encoder := json.NewEncoder(s.writer)
+	encoder.SetEscapeHTML(false)
+	for _, event := range s.buffer {
+		if err := encoder.Encode(event); err != nil {
+			return err
+		}
+	}
+	s.buffer = s.buffer[:0]
+	return s.writer.Flush()
+}
+
+func (s *JSONSink) Close(ctx context.Context) error {
+	close(s.shutdown)
+	s.ticker.Stop()
+	flushErr := s.Flush()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var closeErr error
+	if s.file != nil {
+		cErr := s.file.Close()
+		if cErr != nil {
+			closeErr = cErr
+		}
+	}
+	if flushErr != nil {
+		if closeErr != nil {
+			return errors.Join(flushErr, closeErr)
+		}
+		return flushErr
+	}
+	return closeErr
+}
+
+func cloneForJSON(event logging.Event) logging.Event {
+	cloned := event
+	if len(event.Targets) > 0 {
+		cloned.Targets = append([]logging.EntityRef(nil), event.Targets...)
+	}
+	if event.Extra != nil {
+		copied := make(map[string]any, len(event.Extra))
+		for k, v := range event.Extra {
+			copied[k] = v
+		}
+		cloned.Extra = copied
+	}
+	return cloned
+}

--- a/server/logging/sinks/memory.go
+++ b/server/logging/sinks/memory.go
@@ -1,0 +1,57 @@
+package sinks
+
+import (
+	"context"
+	"sync"
+
+	"mine-and-die/server/logging"
+)
+
+type MemorySink struct {
+	mu     sync.RWMutex
+	events []logging.Event
+}
+
+func NewMemorySink() *MemorySink {
+	return &MemorySink{events: make([]logging.Event, 0)}
+}
+
+func (s *MemorySink) Write(event logging.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, cloneForMemory(event))
+	return nil
+}
+
+func (s *MemorySink) Events() []logging.Event {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	copied := make([]logging.Event, len(s.events))
+	copy(copied, s.events)
+	return copied
+}
+
+func (s *MemorySink) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = s.events[:0]
+}
+
+func (s *MemorySink) Close(context.Context) error {
+	return nil
+}
+
+func cloneForMemory(event logging.Event) logging.Event {
+	cloned := event
+	if len(event.Targets) > 0 {
+		cloned.Targets = append([]logging.EntityRef(nil), event.Targets...)
+	}
+	if event.Extra != nil {
+		copied := make(map[string]any, len(event.Extra))
+		for k, v := range event.Extra {
+			copied[k] = v
+		}
+		cloned.Extra = copied
+	}
+	return cloned
+}

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"mine-and-die/server/logging"
 )
 
 func findPlayer(players []Player, id string) *Player {
@@ -153,8 +155,8 @@ func TestWorldGenerationDeterministicWithSeed(t *testing.T) {
 	cfg := defaultWorldConfig()
 	cfg.Seed = "deterministic-test"
 
-	w1 := newWorld(cfg)
-	w2 := newWorld(cfg)
+	w1 := newWorld(cfg, logging.NopPublisher())
+	w2 := newWorld(cfg, logging.NopPublisher())
 
 	if len(w1.obstacles) != len(w2.obstacles) {
 		t.Fatalf("expected identical obstacle counts, got %d and %d", len(w1.obstacles), len(w2.obstacles))
@@ -166,7 +168,7 @@ func TestWorldGenerationDeterministicWithSeed(t *testing.T) {
 	}
 
 	cfg.Seed = "deterministic-test-alt"
-	w3 := newWorld(cfg)
+	w3 := newWorld(cfg, logging.NopPublisher())
 
 	if len(w1.obstacles) != len(w3.obstacles) {
 		return


### PR DESCRIPTION
## Summary
- add a new server/logging package that defines events, router orchestration, and console/json/memory sinks
- document the logging model and wire the router into main so hubs/worlds receive a structured publisher
- replace the melee attack overlap printf with a combat domain helper that publishes structured events

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e5f3a96ca8832f96d1f0be0c48f942