### PR TITLE
Add telemetry for combat damage and lifecycle events

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -101,6 +101,12 @@ All event types must be documented to keep downstream sinks stable. Current cove
 | Event Type | Helper | Payload | Description |
 | --- | --- | --- | --- |
 | `combat.attack_overlap` | `combat.AttackOverlap` | `AttackOverlapPayload` (`ability`, `playerHits`, `npcHits`) | Emitted when a combat ability hits multiple targets during a single tick. Actor/targets identify the source and impacted entities. |
+| `combat.damage` | `combat.Damage` | `DamagePayload` (`ability`, `amount`, `targetHealth`, `condition`) | Fired whenever an ability reduces a target's health. `condition` is set when periodic effects (e.g. burning) apply the tick. |
+| `combat.defeat` | `combat.Defeat` | `DefeatPayload` (`ability`, `condition`) | Fired when damage reduces a target to zero health. Targets contain the defeated entity for downstream kill feeds. |
+| `conditions.applied` | `conditions.Applied` | `AppliedPayload` (`condition`, `sourceId`, `durationMs`) | Published when a status condition is first applied to an actor. Actor references the applier (if known); target references the recipient. |
+| `lifecycle.player_joined` | `lifecycle.PlayerJoined` | `PlayerJoinedPayload` (`spawnX`, `spawnY`) | Signals that a new player has joined the shard along with their spawn coordinates. |
+| `lifecycle.player_disconnected` | `lifecycle.PlayerDisconnected` | `PlayerDisconnectedPayload` (`reason`) | Signals that a player left the world. `reason` differentiates manual disconnects from heartbeat timeouts. |
+| `economy.item_grant_failed` | `economy.ItemGrantFailed` | `ItemGrantFailedPayload` (`itemType`, `quantity`, `reason`) | Warn-level event emitted when inventories reject a grant (player seeding, NPC rewards, mining, etc.). The error string is attached via `Event.Extra`. |
 
 Extend this table whenever new helpers are added.
 

--- a/server/logging/combat/helpers.go
+++ b/server/logging/combat/helpers.go
@@ -9,6 +9,10 @@ import (
 const (
 	// EventAttackOverlap is emitted when an attack overlaps multiple actors.
 	EventAttackOverlap logging.EventType = "combat.attack_overlap"
+	// EventDamage is emitted when an ability deals damage to a target.
+	EventDamage logging.EventType = "combat.damage"
+	// EventDefeat is emitted when an actor is defeated.
+	EventDefeat logging.EventType = "combat.defeat"
 )
 
 // AttackOverlapPayload captures the targets affected by an overlapping attack.
@@ -16,6 +20,20 @@ type AttackOverlapPayload struct {
 	Ability    string   `json:"ability"`
 	PlayerHits []string `json:"playerHits,omitempty"`
 	NPCHits    []string `json:"npcHits,omitempty"`
+}
+
+// DamagePayload captures the amount dealt to a single target.
+type DamagePayload struct {
+	Ability      string  `json:"ability,omitempty"`
+	Amount       float64 `json:"amount"`
+	TargetHealth float64 `json:"targetHealth"`
+	Condition    string  `json:"condition,omitempty"`
+}
+
+// DefeatPayload describes the context for a fatal blow.
+type DefeatPayload struct {
+	Ability   string `json:"ability,omitempty"`
+	Condition string `json:"condition,omitempty"`
 }
 
 // AttackOverlap publishes a combat overlap event.
@@ -28,6 +46,42 @@ func AttackOverlap(ctx context.Context, pub logging.Publisher, tick uint64, acto
 		Tick:     tick,
 		Actor:    actor,
 		Targets:  targets,
+		Severity: logging.SeverityInfo,
+		Category: "combat",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}
+
+// Damage publishes a combat damage event for a single target.
+func Damage(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, target logging.EntityRef, payload DamagePayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventDamage,
+		Tick:     tick,
+		Actor:    actor,
+		Targets:  []logging.EntityRef{target},
+		Severity: logging.SeverityInfo,
+		Category: "combat",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}
+
+// Defeat publishes a combat defeat event for the eliminated actor.
+func Defeat(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, target logging.EntityRef, payload DefeatPayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventDefeat,
+		Tick:     tick,
+		Actor:    actor,
+		Targets:  []logging.EntityRef{target},
 		Severity: logging.SeverityInfo,
 		Category: "combat",
 		Payload:  payload,

--- a/server/logging/conditions/helpers.go
+++ b/server/logging/conditions/helpers.go
@@ -1,0 +1,37 @@
+package conditions
+
+import (
+	"context"
+
+	"mine-and-die/server/logging"
+)
+
+const (
+	// EventApplied is emitted when a condition is applied to an actor.
+	EventApplied logging.EventType = "conditions.applied"
+)
+
+// AppliedPayload captures details about a condition application.
+type AppliedPayload struct {
+	Condition  string `json:"condition"`
+	SourceID   string `json:"sourceId,omitempty"`
+	DurationMs int64  `json:"durationMs,omitempty"`
+}
+
+// Applied publishes a condition application event.
+func Applied(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, target logging.EntityRef, payload AppliedPayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventApplied,
+		Tick:     tick,
+		Actor:    actor,
+		Targets:  []logging.EntityRef{target},
+		Severity: logging.SeverityInfo,
+		Category: "conditions",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}

--- a/server/logging/economy/helpers.go
+++ b/server/logging/economy/helpers.go
@@ -1,0 +1,36 @@
+package economy
+
+import (
+	"context"
+
+	"mine-and-die/server/logging"
+)
+
+const (
+	// EventItemGrantFailed is emitted when the server fails to add an item to an inventory.
+	EventItemGrantFailed logging.EventType = "economy.item_grant_failed"
+)
+
+// ItemGrantFailedPayload describes the attempted item grant.
+type ItemGrantFailedPayload struct {
+	ItemType string `json:"itemType"`
+	Quantity int    `json:"quantity,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// ItemGrantFailed publishes an event for a failed inventory grant.
+func ItemGrantFailed(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, payload ItemGrantFailedPayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventItemGrantFailed,
+		Tick:     tick,
+		Actor:    actor,
+		Severity: logging.SeverityWarn,
+		Category: "economy",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}

--- a/server/logging/lifecycle/helpers.go
+++ b/server/logging/lifecycle/helpers.go
@@ -1,0 +1,59 @@
+package lifecycle
+
+import (
+	"context"
+
+	"mine-and-die/server/logging"
+)
+
+const (
+	// EventPlayerJoined is emitted when a player joins the world.
+	EventPlayerJoined logging.EventType = "lifecycle.player_joined"
+	// EventPlayerDisconnected is emitted when a player leaves the world.
+	EventPlayerDisconnected logging.EventType = "lifecycle.player_disconnected"
+)
+
+// PlayerJoinedPayload captures spawn metadata for a new player.
+type PlayerJoinedPayload struct {
+	SpawnX float64 `json:"spawnX"`
+	SpawnY float64 `json:"spawnY"`
+}
+
+// PlayerDisconnectedPayload captures the reason a player left.
+type PlayerDisconnectedPayload struct {
+	Reason string `json:"reason"`
+}
+
+// PlayerJoined publishes a player join event.
+func PlayerJoined(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, payload PlayerJoinedPayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventPlayerJoined,
+		Tick:     tick,
+		Actor:    actor,
+		Severity: logging.SeverityInfo,
+		Category: "lifecycle",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}
+
+// PlayerDisconnected publishes a player disconnect event.
+func PlayerDisconnected(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, payload PlayerDisconnectedPayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventPlayerDisconnected,
+		Tick:     tick,
+		Actor:    actor,
+		Severity: logging.SeverityInfo,
+		Category: "lifecycle",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}


### PR DESCRIPTION
## Summary
- add logging helper packages for combat damage/defeat, conditions, lifecycle, and economy failures
- emit structured events for damage ticks, condition applications, player joins/disconnects, and replace legacy log.Printf usage
- document the new event types in the logging guide

## Testing
- go test ./...

------
https://chatgpt.com/codex/tasks/task_e_68e6058521d0832fad5f7e8628aef11a