### PR TITLE
Reduce goblin pursuit detection distances

### DIFF
--- a/server/ai_configs/goblin.json
+++ b/server/ai_configs/goblin.json
@@ -13,7 +13,7 @@
         { "name": "moveToward", "target": "waypoint" }
       ],
       "transitions": [
-        { "if": "playerWithin", "radius": 320, "to": "Pursue" },
+        { "if": "playerWithin", "radius": 160, "to": "Pursue" },
         { "if": "reachedWaypoint", "to": "Wait" }
       ]
     },
@@ -24,7 +24,7 @@
         { "name": "moveToward", "target": "player" }
       ],
       "transitions": [
-        { "if": "lostSight", "distance": 360, "to": "Patrol" }
+        { "if": "lostSight", "distance": 180, "to": "Patrol" }
       ]
     },
     {
@@ -37,7 +37,7 @@
         { "name": "setWaypoint", "advance": true }
       ],
       "transitions": [
-        { "if": "playerWithin", "radius": 320, "to": "Pursue" },
+        { "if": "playerWithin", "radius": 160, "to": "Pursue" },
         { "if": "timerExpired", "to": "Patrol" }
       ]
     }


### PR DESCRIPTION
## Summary
- halve the goblin AI's pursuit detection radius and loss-of-sight distance to make chases shorter

## Testing
- go test ./...

------
https://chatgpt.com/codex/tasks/task_e_68e612dd5514832f9962d5ca996ee246