### PR TITLE
Expand default world bounds

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -3,6 +3,8 @@ import {
   resetWorld,
   sendMoveTo,
   DEFAULT_WORLD_SEED,
+  DEFAULT_WORLD_WIDTH,
+  DEFAULT_WORLD_HEIGHT,
 } from "./network.js";
 import { startRenderLoop } from "./render.js";
 import { registerInputHandlers } from "./input.js";
@@ -90,6 +92,8 @@ const DEFAULT_WORLD_CONFIG = {
   lava: true,
   lavaCount: 3,
   seed: DEFAULT_WORLD_SEED,
+  width: DEFAULT_WORLD_WIDTH,
+  height: DEFAULT_WORLD_HEIGHT,
 };
 
 const store = {
@@ -133,8 +137,8 @@ const store = {
   TILE_SIZE: 40,
   GRID_WIDTH: canvas.width / 40,
   GRID_HEIGHT: canvas.height / 40,
-  WORLD_WIDTH: canvas.width,
-  WORLD_HEIGHT: canvas.height,
+  WORLD_WIDTH: DEFAULT_WORLD_CONFIG.width,
+  WORLD_HEIGHT: DEFAULT_WORLD_CONFIG.height,
   PLAYER_SIZE: 28,
   PLAYER_HALF: 28 / 2,
   LERP_RATE: 12,

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Welcome to the documentation set for the Mine & Die prototype. The project explo
 5. Both sides exchange heartbeats every ~2 seconds; the acknowledgements update latency diagnostics and missed heartbeats enqueue disconnect commands.
 
 ## Simulation Quick Facts
-- World bounds: 800×600 pixels with obstacles and ore nodes generated from a configurable deterministic seed.
+- World bounds: 2400×1800 pixels with obstacles and ore nodes generated from a configurable deterministic seed.
 - Player speed: ~160 px/s with server-side clamping and separation to avoid overlap.
 - Effects: Melee swings and fireballs live as time-bound rectangles; fire-and-forget triggers let the server hand off one-shot visuals without keeping placeholder effects alive.
 - Disconnect policy: three missed heartbeats (~6s) remove the player from the hub.

--- a/server/constants.go
+++ b/server/constants.go
@@ -6,8 +6,10 @@ const (
 	writeWait             = 10 * time.Second
 	tickRate              = 15    // ticks per second (10–20 Hz)
 	moveSpeed             = 160.0 // pixels per second
-	worldWidth            = 800.0
-	worldHeight           = 600.0
+	worldWidth            = 2400.0
+	worldHeight           = 1800.0
+	defaultSpawnX         = worldWidth / 2
+	defaultSpawnY         = worldHeight / 2
 	playerHalf            = 14.0
 	playerMaxHealth       = 100.0
 	lavaDamagePerSecond   = 20.0

--- a/server/hub.go
+++ b/server/hub.go
@@ -82,8 +82,8 @@ func (h *Hub) seedPlayerState(playerID string, now time.Time) *playerState {
 		actorState: actorState{
 			Actor: Actor{
 				ID:        playerID,
-				X:         80,
-				Y:         80,
+				X:         defaultSpawnX,
+				Y:         defaultSpawnY,
 				Facing:    defaultFacing,
 				Health:    playerMaxHealth,
 				MaxHealth: playerMaxHealth,

--- a/server/obstacles.go
+++ b/server/obstacles.go
@@ -56,7 +56,7 @@ func (w *World) generateObstacles(count int) []Obstacle {
 				Height: height,
 			}
 
-			if circleRectOverlap(80, 80, playerSpawnSafeRadius, candidate) {
+			if circleRectOverlap(defaultSpawnX, defaultSpawnY, playerSpawnSafeRadius, candidate) {
 				continue
 			}
 
@@ -124,7 +124,7 @@ func (w *World) generateGoldOreNodes(count int, existing []Obstacle, rng *rand.R
 			Height: height,
 		}
 
-		if circleRectOverlap(80, 80, playerSpawnSafeRadius, candidate) {
+		if circleRectOverlap(defaultSpawnX, defaultSpawnY, playerSpawnSafeRadius, candidate) {
 			continue
 		}
 

--- a/server/world_config.go
+++ b/server/world_config.go
@@ -6,17 +6,19 @@ const defaultWorldSeed = "prototype"
 
 // worldConfig captures the toggles used when generating a world.
 type worldConfig struct {
-	Obstacles      bool   `json:"obstacles"`
-	ObstaclesCount int    `json:"obstaclesCount"`
-	GoldMines      bool   `json:"goldMines"`
-	GoldMineCount  int    `json:"goldMineCount"`
-	NPCs           bool   `json:"npcs"`
-	GoblinCount    int    `json:"goblinCount"`
-	RatCount       int    `json:"ratCount"`
-	NPCCount       int    `json:"npcCount"`
-	Lava           bool   `json:"lava"`
-	LavaCount      int    `json:"lavaCount"`
-	Seed           string `json:"seed"`
+	Obstacles      bool    `json:"obstacles"`
+	ObstaclesCount int     `json:"obstaclesCount"`
+	GoldMines      bool    `json:"goldMines"`
+	GoldMineCount  int     `json:"goldMineCount"`
+	NPCs           bool    `json:"npcs"`
+	GoblinCount    int     `json:"goblinCount"`
+	RatCount       int     `json:"ratCount"`
+	NPCCount       int     `json:"npcCount"`
+	Lava           bool    `json:"lava"`
+	LavaCount      int     `json:"lavaCount"`
+	Seed           string  `json:"seed"`
+	Width          float64 `json:"width"`
+	Height         float64 `json:"height"`
 }
 
 // normalized returns a config with defaults applied.
@@ -45,6 +47,12 @@ func (cfg worldConfig) normalized() worldConfig {
 		normalized.LavaCount = 0
 	}
 	normalized.NPCCount = normalized.GoblinCount + normalized.RatCount
+	if normalized.Width <= 0 {
+		normalized.Width = worldWidth
+	}
+	if normalized.Height <= 0 {
+		normalized.Height = worldHeight
+	}
 	return normalized
 }
 
@@ -62,5 +70,7 @@ func defaultWorldConfig() worldConfig {
 		Lava:           true,
 		LavaCount:      defaultLavaCount,
 		Seed:           defaultWorldSeed,
+		Width:          worldWidth,
+		Height:         worldHeight,
 	}
 }


### PR DESCRIPTION
## Summary
- expand the world dimensions to 2400x1800 and surface the values through the world config
- spawn players in the center of the enlarged map while keeping the spawn area obstacle-free
- sync client defaults and documentation with the new world size

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e61508cc0c832fac06925f3af5410f