### PR TITLE
Relocate world reset controls to header

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,7 +8,46 @@
   </head>
   <body>
     <main>
-      <h1>Mine and Die Prototype</h1>
+      <header class="page-header">
+        <h1 class="page-header__title">Mine and Die Prototype</h1>
+        <div class="page-header__controls">
+          <div class="page-header__seed">
+            <label class="page-header__seed-label" for="world-reset-seed">
+              World seed
+            </label>
+            <input
+              id="world-reset-seed"
+              name="seed"
+              type="text"
+              inputmode="text"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="prototype"
+              class="world-reset-field__input"
+              aria-describedby="world-reset-seed-hint"
+              form="world-reset-form"
+            />
+            <p id="world-reset-seed-hint" class="page-header__seed-hint">
+              Runs with the same seed produce identical obstacle layouts and AI randomness.
+            </p>
+          </div>
+          <div class="page-header__actions">
+            <button
+              type="submit"
+              class="world-reset-button"
+              form="world-reset-form"
+            >
+              Restart world
+            </button>
+            <p
+              id="world-reset-status"
+              class="world-reset-status"
+              role="status"
+              aria-live="polite"
+            ></p>
+          </div>
+        </div>
+      </header>
       <div class="play-area">
         <div class="play-area__main">
           <canvas id="game-canvas" width="800" height="600"></canvas>
@@ -175,34 +214,6 @@
                     >
                   </label>
                 </div>
-              </div>
-              <div class="world-reset-field">
-                <label class="world-reset-field__label" for="world-reset-seed">
-                  World seed
-                </label>
-                <input
-                  id="world-reset-seed"
-                  name="seed"
-                  type="text"
-                  inputmode="text"
-                  autocomplete="off"
-                  spellcheck="false"
-                  placeholder="prototype"
-                  class="world-reset-field__input"
-                  aria-describedby="world-reset-seed-hint"
-                />
-                <p id="world-reset-seed-hint" class="world-reset-field__hint">
-                  Runs with the same seed produce identical obstacle layouts and AI randomness.
-                </p>
-              </div>
-              <div class="world-reset-actions">
-                <button type="submit" class="world-reset-button">Restart world</button>
-                <p
-                  id="world-reset-status"
-                  class="world-reset-status"
-                  role="status"
-                  aria-live="polite"
-                ></p>
               </div>
             </form>
           </section>

--- a/client/styles.css
+++ b/client/styles.css
@@ -23,11 +23,54 @@ main {
 
 h1 {
   margin: 0;
-  font-size: 2.25rem;
-  letter-spacing: 0.06em;
+  font-size: 1.75rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  text-align: center;
   color: #e2e8f0;
+  text-align: left;
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+}
+
+.page-header__controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem 1.25rem;
+  flex: 1 1 320px;
+}
+
+.page-header__seed {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 220px;
+  flex: 1 1 260px;
+}
+
+.page-header__seed-label {
+  font-weight: 600;
+  color: #f8fafc;
+  font-size: 0.95rem;
+}
+
+.page-header__seed-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.page-header__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
 }
 
 .play-area {
@@ -574,6 +617,19 @@ canvas {
   main {
     width: calc(100% - 2rem);
     margin: 2rem auto;
+  }
+
+  .page-header {
+    align-items: stretch;
+  }
+
+  .page-header__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .page-header__actions {
+    width: 100%;
   }
 
   .debug-panel__header {


### PR DESCRIPTION
## Summary
- move the world seed input and restart button into a new header layout above the play area
- shrink the title styling and add responsive header rules so the controls sit alongside it on wide screens

## Testing
- Manual UI verification (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68e6157ea354832fbd2645d64461f378