### PR TITLE
Center obstacle and NPC spawns around the player

### DIFF
--- a/server/obstacles.go
+++ b/server/obstacles.go
@@ -39,14 +39,33 @@ func (w *World) generateObstacles(count int) []Obstacle {
 			width := obstacleMinWidth + rng.Float64()*(obstacleMaxWidth-obstacleMinWidth)
 			height := obstacleMinHeight + rng.Float64()*(obstacleMaxHeight-obstacleMinHeight)
 
-			maxX := worldWidth - obstacleSpawnMargin - width
-			maxY := worldHeight - obstacleSpawnMargin - height
-			if maxX <= obstacleSpawnMargin || maxY <= obstacleSpawnMargin {
+			globalMinX := obstacleSpawnMargin
+			globalMaxX := worldWidth - obstacleSpawnMargin - width
+			globalMinY := obstacleSpawnMargin
+			globalMaxY := worldHeight - obstacleSpawnMargin - height
+			if globalMaxX <= globalMinX || globalMaxY <= globalMinY {
 				break
 			}
 
-			x := obstacleSpawnMargin + rng.Float64()*(maxX-obstacleSpawnMargin)
-			y := obstacleSpawnMargin + rng.Float64()*(maxY-obstacleSpawnMargin)
+			minX, maxX := centralTopLeftRange(worldWidth, defaultSpawnX, obstacleSpawnMargin, width)
+			if maxX <= minX {
+				minX = globalMinX
+				maxX = globalMaxX
+			}
+			minY, maxY := centralTopLeftRange(worldHeight, defaultSpawnY, obstacleSpawnMargin, height)
+			if maxY <= minY {
+				minY = globalMinY
+				maxY = globalMaxY
+			}
+
+			x := minX
+			if maxX > minX {
+				x += rng.Float64() * (maxX - minX)
+			}
+			y := minY
+			if maxY > minY {
+				y += rng.Float64() * (maxY - minY)
+			}
 
 			candidate := Obstacle{
 				ID:     fmt.Sprintf("obstacle-%d", len(obstacles)+1),
@@ -106,14 +125,33 @@ func (w *World) generateGoldOreNodes(count int, existing []Obstacle, rng *rand.R
 		width := goldOreMinSize + rng.Float64()*(goldOreMaxSize-goldOreMinSize)
 		height := goldOreMinSize + rng.Float64()*(goldOreMaxSize-goldOreMinSize)
 
-		maxX := worldWidth - obstacleSpawnMargin - width
-		maxY := worldHeight - obstacleSpawnMargin - height
-		if maxX <= obstacleSpawnMargin || maxY <= obstacleSpawnMargin {
+		globalMinX := obstacleSpawnMargin
+		globalMaxX := worldWidth - obstacleSpawnMargin - width
+		globalMinY := obstacleSpawnMargin
+		globalMaxY := worldHeight - obstacleSpawnMargin - height
+		if globalMaxX <= globalMinX || globalMaxY <= globalMinY {
 			break
 		}
 
-		x := obstacleSpawnMargin + rng.Float64()*(maxX-obstacleSpawnMargin)
-		y := obstacleSpawnMargin + rng.Float64()*(maxY-obstacleSpawnMargin)
+		minX, maxX := centralTopLeftRange(worldWidth, defaultSpawnX, obstacleSpawnMargin, width)
+		if maxX <= minX {
+			minX = globalMinX
+			maxX = globalMaxX
+		}
+		minY, maxY := centralTopLeftRange(worldHeight, defaultSpawnY, obstacleSpawnMargin, height)
+		if maxY <= minY {
+			minY = globalMinY
+			maxY = globalMaxY
+		}
+
+		x := minX
+		if maxX > minX {
+			x += rng.Float64() * (maxX - minX)
+		}
+		y := minY
+		if maxY > minY {
+			y += rng.Float64() * (maxY - minY)
+		}
 
 		candidate := Obstacle{
 			ID:     fmt.Sprintf("gold-ore-%d", len(ores)+1),

--- a/server/simulation.go
+++ b/server/simulation.go
@@ -371,23 +371,30 @@ func (w *World) spawnInitialNPCs() {
 		return
 	}
 
+	centerX := defaultSpawnX
+	centerY := defaultSpawnY
+
 	goblinsSpawned := 0
 	if goblinTarget >= 1 {
-		w.spawnGoblinAt(360, 260, []vec2{
-			{X: 360, Y: 260},
-			{X: 480, Y: 260},
-			{X: 480, Y: 380},
-			{X: 360, Y: 380},
+		patrolOffset := 160.0
+		w.spawnGoblinAt(centerX-patrolOffset, centerY-patrolOffset, []vec2{
+			{X: centerX - patrolOffset, Y: centerY - patrolOffset},
+			{X: centerX + patrolOffset, Y: centerY - patrolOffset},
+			{X: centerX + patrolOffset, Y: centerY + patrolOffset},
+			{X: centerX - patrolOffset, Y: centerY + patrolOffset},
 		}, 12, 1)
 		goblinsSpawned++
 	}
 	if goblinTarget >= 2 {
-		w.spawnGoblinAt(640, 480, []vec2{
-			{X: 640, Y: 480},
-			{X: 760, Y: 480},
-			{X: 760, Y: 600},
-			{X: 520, Y: 600},
-			{X: 520, Y: 480},
+		topLeftX := centerX + 120.0
+		height := 220.0
+		width := 220.0
+		topLeftY := centerY - height/2
+		w.spawnGoblinAt(topLeftX, topLeftY, []vec2{
+			{X: topLeftX, Y: topLeftY},
+			{X: topLeftX + width, Y: topLeftY},
+			{X: topLeftX + width, Y: topLeftY + height},
+			{X: topLeftX, Y: topLeftY + height},
 		}, 8, 1)
 		goblinsSpawned++
 	}
@@ -398,7 +405,7 @@ func (w *World) spawnInitialNPCs() {
 
 	ratsSpawned := 0
 	if ratTarget >= 1 {
-		w.spawnRatAt(280, 520)
+		w.spawnRatAt(centerX-200, centerY+240)
 		ratsSpawned++
 	}
 	extraRats := ratTarget - ratsSpawned
@@ -505,6 +512,17 @@ func (w *World) spawnExtraGoblins(count int) {
 		maxY = worldHeight - playerHalf - patrolRadius
 	}
 
+	centralMinX, centralMaxX := centralCenterRange(worldWidth, defaultSpawnX, obstacleSpawnMargin, patrolRadius)
+	if centralMaxX >= centralMinX {
+		minX = centralMinX
+		maxX = centralMaxX
+	}
+	centralMinY, centralMaxY := centralCenterRange(worldHeight, defaultSpawnY, obstacleSpawnMargin, patrolRadius)
+	if centralMaxY >= centralMinY {
+		minY = centralMinY
+		maxY = centralMaxY
+	}
+
 	for i := 0; i < count; i++ {
 		x := minX
 		if maxX > minX {
@@ -587,9 +605,18 @@ func (w *World) spawnExtraRats(count int) {
 		return
 	}
 	rng := w.subsystemRNG("npcs.extra")
+	minX, maxX := centralCenterRange(worldWidth, defaultSpawnX, obstacleSpawnMargin, playerHalf)
+	minY, maxY := centralCenterRange(worldHeight, defaultSpawnY, obstacleSpawnMargin, playerHalf)
+
 	for i := 0; i < count; i++ {
-		x := obstacleSpawnMargin + rng.Float64()*(worldWidth-2*obstacleSpawnMargin)
-		y := obstacleSpawnMargin + rng.Float64()*(worldHeight-2*obstacleSpawnMargin)
+		x := minX
+		if maxX > minX {
+			x = minX + rng.Float64()*(maxX-minX)
+		}
+		y := minY
+		if maxY > minY {
+			y = minY + rng.Float64()*(maxY-minY)
+		}
 		w.spawnRatAt(x, y)
 	}
 }

--- a/server/world_random.go
+++ b/server/world_random.go
@@ -6,6 +6,8 @@ import (
 	"math/rand"
 )
 
+const centralSpawnRegionRatio = 0.5
+
 func deterministicSeedValue(rootSeed, label string) int64 {
 	hasher := fnv.New64a()
 	hasher.Write([]byte(rootSeed))
@@ -60,4 +62,51 @@ func (w *World) randomDistance(min, max float64) float64 {
 		return min
 	}
 	return min + w.randomFloat()*(max-min)
+}
+
+func centralTopLeftRange(total, center, margin, size float64) (float64, float64) {
+	if total <= 0 {
+		return margin, margin
+	}
+
+	regionHalf := total * centralSpawnRegionRatio / 2
+	min := center - regionHalf
+	max := center + regionHalf - size
+
+	if min < margin {
+		min = margin
+	}
+	maxLimit := total - margin - size
+	if max > maxLimit {
+		max = maxLimit
+	}
+	if max < min {
+		max = min
+	}
+
+	return min, max
+}
+
+func centralCenterRange(total, center, margin, padding float64) (float64, float64) {
+	if total <= 0 {
+		return margin, margin
+	}
+
+	regionHalf := total * centralSpawnRegionRatio / 2
+	min := center - regionHalf
+	max := center + regionHalf
+
+	minLimit := margin + padding
+	if min < minLimit {
+		min = minLimit
+	}
+	maxLimit := total - margin - padding
+	if max > maxLimit {
+		max = maxLimit
+	}
+	if max < min {
+		max = min
+	}
+
+	return min, max
 }


### PR DESCRIPTION
## Summary
- focus obstacle and gold ore placement within the central region of the world
- move scripted goblin and rat patrols to start near the player spawn
- reuse new helpers so extra goblins and rats roll positions around the default spawn

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e62b816330832f81562f32b78e3efa