### PR TITLE
Implement ground gold system with console commands

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -2,6 +2,8 @@ import {
   joinGame,
   resetWorld,
   sendMoveTo,
+  sendConsoleDropGold,
+  sendConsolePickupGold,
   DEFAULT_WORLD_SEED,
   DEFAULT_WORLD_WIDTH,
   DEFAULT_WORLD_HEIGHT,
@@ -174,8 +176,11 @@ const store = {
   bytesSent: 0,
   lastPathRequestAt: null,
   effects: [],
+  groundItems: [],
   pendingEffectTriggers: [],
   processedEffectTriggerIds: new Set(),
+  consoleToast: null,
+  lastConsoleAck: null,
   camera: {
     x: 0,
     y: 0,
@@ -757,6 +762,15 @@ store.renderInventory = renderInventory;
 store.updateWorldConfigUI = () => syncWorldResetControls();
 store.setCameraLock = setCameraLock;
 store.toggleCameraLock = toggleCameraLock;
+
+if (typeof window !== "undefined") {
+  window.debugDropGold = (quantity) => {
+    sendConsoleDropGold(store, quantity);
+  };
+  window.debugPickupGold = () => {
+    sendConsolePickupGold(store);
+  };
+}
 
 initializeDebugPanelToggle();
 attachLatencyInputListener();

--- a/server/constants.go
+++ b/server/constants.go
@@ -8,6 +8,7 @@ const (
 	moveSpeed             = 160.0 // pixels per second
 	worldWidth            = 2400.0
 	worldHeight           = 1800.0
+	tileSize              = 40.0
 	defaultSpawnX         = worldWidth / 2
 	defaultSpawnY         = worldHeight / 2
 	playerHalf            = 14.0

--- a/server/effects.go
+++ b/server/effects.go
@@ -201,6 +201,10 @@ func healthDeltaBehavior(param string, fallback float64) effectBehavior {
 		if delta == 0 {
 			return
 		}
+		wasAlive := false
+		if target != nil {
+			wasAlive = target.Health > 0
+		}
 		if target.applyHealthDelta(delta) {
 			if w != nil && delta < 0 {
 				ability := ""
@@ -242,6 +246,9 @@ func healthDeltaBehavior(param string, fallback float64) effectBehavior {
 						nil,
 					)
 				}
+			}
+			if w != nil && wasAlive && target.Health <= 0 {
+				w.dropAllGold(target, "death")
 			}
 		}
 	})

--- a/server/ground_items.go
+++ b/server/ground_items.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	loggingeconomy "mine-and-die/server/logging/economy"
+)
+
+// GroundItem represents a stack of gold dropped on the ground.
+type GroundItem struct {
+	ID    string  `json:"id"`
+	X     float64 `json:"x"`
+	Y     float64 `json:"y"`
+	Qty   int     `json:"qty"`
+	tileX int
+	tileY int
+}
+
+func groundTileKey(tileX, tileY int) string {
+	return fmt.Sprintf("%d:%d", tileX, tileY)
+}
+
+func quantizeToTile(x, y float64) (int, int, float64, float64) {
+	tileX := int(math.Floor(x / tileSize))
+	tileY := int(math.Floor(y / tileSize))
+	centerX := (float64(tileX) + 0.5) * tileSize
+	centerY := (float64(tileY) + 0.5) * tileSize
+	return tileX, tileY, centerX, centerY
+}
+
+func (w *World) spawnGroundGold(x, y float64, qty int) *GroundItem {
+	if w == nil || qty <= 0 {
+		return nil
+	}
+	tileX, tileY, centerX, centerY := quantizeToTile(x, y)
+	key := groundTileKey(tileX, tileY)
+	if w.groundIndex == nil {
+		w.groundIndex = make(map[string]string)
+	}
+	if w.groundItems == nil {
+		w.groundItems = make(map[string]*GroundItem)
+	}
+	if existingID, ok := w.groundIndex[key]; ok {
+		if existing, ok := w.groundItems[existingID]; ok && existing != nil {
+			existing.Qty += qty
+			existing.X = centerX
+			existing.Y = centerY
+			existing.tileX = tileX
+			existing.tileY = tileY
+			w.groundIndex[key] = existing.ID
+			return existing
+		}
+	}
+
+	w.nextGroundItemID++
+	id := fmt.Sprintf("ground-%d", w.nextGroundItemID)
+	item := &GroundItem{ID: id, X: centerX, Y: centerY, Qty: qty, tileX: tileX, tileY: tileY}
+	w.groundItems[id] = item
+	w.groundIndex[key] = id
+	return item
+}
+
+func (w *World) closestGroundItem(x, y float64) (*GroundItem, float64) {
+	if w == nil || len(w.groundItems) == 0 {
+		return nil, math.MaxFloat64
+	}
+	bestDistance := math.MaxFloat64
+	var bestItem *GroundItem
+	bestID := ""
+	for id, item := range w.groundItems {
+		if item == nil || item.Qty <= 0 {
+			continue
+		}
+		dx := item.X - x
+		dy := item.Y - y
+		dist := math.Hypot(dx, dy)
+		if dist+1e-6 < bestDistance {
+			bestDistance = dist
+			bestItem = item
+			bestID = id
+			continue
+		}
+		if math.Abs(dist-bestDistance) <= 1e-6 && bestItem != nil && id < bestID {
+			bestItem = item
+			bestID = id
+		}
+	}
+	if bestItem == nil {
+		return nil, math.MaxFloat64
+	}
+	return bestItem, bestDistance
+}
+
+func (w *World) removeGroundItem(id string) {
+	if w == nil || id == "" {
+		return
+	}
+	item, ok := w.groundItems[id]
+	if !ok {
+		return
+	}
+	delete(w.groundItems, id)
+	key := groundTileKey(item.tileX, item.tileY)
+	if existing, ok := w.groundIndex[key]; ok && existing == id {
+		delete(w.groundIndex, key)
+	}
+}
+
+func (w *World) dropAllGold(actor *actorState, reason string) int {
+	if w == nil || actor == nil {
+		return 0
+	}
+	total := 0
+	for i := len(actor.Inventory.Slots) - 1; i >= 0; i-- {
+		slot := actor.Inventory.Slots[i]
+		if slot.Item.Type != ItemTypeGold {
+			continue
+		}
+		qty := slot.Item.Quantity
+		if qty <= 0 {
+			continue
+		}
+		if _, err := actor.Inventory.RemoveQuantity(i, qty); err != nil {
+			continue
+		}
+		total += qty
+	}
+	if total > 0 {
+		w.spawnGroundGold(actor.X, actor.Y, total)
+		loggingeconomy.GoldDropped(
+			context.Background(),
+			w.publisher,
+			w.currentTick,
+			w.entityRef(actor.ID),
+			loggingeconomy.GoldDroppedPayload{Quantity: total, Reason: reason},
+			nil,
+		)
+	}
+	return total
+}

--- a/server/logging/economy/helpers.go
+++ b/server/logging/economy/helpers.go
@@ -9,6 +9,12 @@ import (
 const (
 	// EventItemGrantFailed is emitted when the server fails to add an item to an inventory.
 	EventItemGrantFailed logging.EventType = "economy.item_grant_failed"
+	// EventGoldDropped is emitted whenever gold is dropped on the ground.
+	EventGoldDropped logging.EventType = "economy.gold_dropped"
+	// EventGoldPickedUp is emitted whenever ground gold is picked up.
+	EventGoldPickedUp logging.EventType = "economy.gold_picked_up"
+	// EventGoldPickupFailed is emitted when a pickup attempt fails.
+	EventGoldPickupFailed logging.EventType = "economy.gold_pickup_failed"
 )
 
 // ItemGrantFailedPayload describes the attempted item grant.
@@ -18,6 +24,22 @@ type ItemGrantFailedPayload struct {
 	Reason   string `json:"reason,omitempty"`
 }
 
+// GoldDroppedPayload describes a gold drop action.
+type GoldDroppedPayload struct {
+	Quantity int    `json:"quantity"`
+	Reason   string `json:"reason"`
+}
+
+// GoldPickedUpPayload describes a successful pickup.
+type GoldPickedUpPayload struct {
+	Quantity int `json:"quantity"`
+}
+
+// GoldPickupFailedPayload describes why a pickup failed.
+type GoldPickupFailedPayload struct {
+	Reason string `json:"reason"`
+}
+
 // ItemGrantFailed publishes an event for a failed inventory grant.
 func ItemGrantFailed(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, payload ItemGrantFailedPayload, extra map[string]any) {
 	if pub == nil {
@@ -25,6 +47,57 @@ func ItemGrantFailed(ctx context.Context, pub logging.Publisher, tick uint64, ac
 	}
 	event := logging.Event{
 		Type:     EventItemGrantFailed,
+		Tick:     tick,
+		Actor:    actor,
+		Severity: logging.SeverityWarn,
+		Category: "economy",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}
+
+// GoldDropped publishes a gold drop event.
+func GoldDropped(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, payload GoldDroppedPayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventGoldDropped,
+		Tick:     tick,
+		Actor:    actor,
+		Severity: logging.SeverityInfo,
+		Category: "economy",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}
+
+// GoldPickedUp publishes a gold pickup event.
+func GoldPickedUp(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, payload GoldPickedUpPayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventGoldPickedUp,
+		Tick:     tick,
+		Actor:    actor,
+		Severity: logging.SeverityInfo,
+		Category: "economy",
+		Payload:  payload,
+		Extra:    extra,
+	}
+	pub.Publish(ctx, event)
+}
+
+// GoldPickupFailed publishes a failed gold pickup event.
+func GoldPickupFailed(ctx context.Context, pub logging.Publisher, tick uint64, actor logging.EntityRef, payload GoldPickupFailedPayload, extra map[string]any) {
+	if pub == nil {
+		return
+	}
+	event := logging.Event{
+		Type:     EventGoldPickupFailed,
 		Tick:     tick,
 		Actor:    actor,
 		Severity: logging.SeverityWarn,

--- a/server/messages.go
+++ b/server/messages.go
@@ -6,6 +6,7 @@ type joinResponse struct {
 	NPCs           []NPC           `json:"npcs"`
 	Obstacles      []Obstacle      `json:"obstacles"`
 	Effects        []Effect        `json:"effects"`
+	GroundItems    []GroundItem    `json:"groundItems"`
 	EffectTriggers []EffectTrigger `json:"effectTriggers,omitempty"`
 	Config         worldConfig     `json:"config"`
 }
@@ -16,6 +17,7 @@ type stateMessage struct {
 	NPCs           []NPC           `json:"npcs"`
 	Obstacles      []Obstacle      `json:"obstacles"`
 	Effects        []Effect        `json:"effects"`
+	GroundItems    []GroundItem    `json:"groundItems"`
 	EffectTriggers []EffectTrigger `json:"effectTriggers,omitempty"`
 	ServerTime     int64           `json:"serverTime"`
 	Config         worldConfig     `json:"config"`
@@ -30,6 +32,8 @@ type clientMessage struct {
 	Y      float64 `json:"y"`
 	SentAt int64   `json:"sentAt"`
 	Action string  `json:"action"`
+	Cmd    string  `json:"cmd"`
+	Qty    int     `json:"qty"`
 }
 
 type heartbeatMessage struct {
@@ -37,6 +41,14 @@ type heartbeatMessage struct {
 	ServerTime int64  `json:"serverTime"`
 	ClientTime int64  `json:"clientTime"`
 	RTTMillis  int64  `json:"rtt"`
+}
+
+type consoleAckMessage struct {
+	Type   string `json:"type"`
+	Cmd    string `json:"cmd"`
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+	Qty    int    `json:"qty,omitempty"`
 }
 
 type diagnosticsPlayer struct {


### PR DESCRIPTION
## Summary
- add ground item management and new economy logging around manual drops, pickups, and death drops
- include ground items in snapshots with console-driven drop/pickup commands and tests for edge cases
- update client to send console commands, render ground gold, and show debug helpers with toast feedback

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e62feabe80832f82081c57c0097b9a