### PR TITLE
Restore client interpolation when applying snapshots

### DIFF
--- a/client/__tests__/network.test.js
+++ b/client/__tests__/network.test.js
@@ -276,16 +276,32 @@ describe("deriveDisplayMaps", () => {
     const { displayPlayers: prunedPlayers, displayNPCs: prunedNPCs } = deriveDisplayMaps(
       { alpha: players.alpha },
       { goblin: npcs.goblin },
+      displayPlayers,
+      displayNPCs,
     );
 
     expect(prunedPlayers).toEqual({ alpha: { x: 1, y: 2 } });
     expect(prunedNPCs).toEqual({ goblin: { x: 7, y: 8 } });
+    expect(prunedPlayers.alpha).toBe(displayPlayers.alpha);
+    expect(prunedNPCs.goblin).toBe(displayNPCs.goblin);
   });
 
   it("handles non-object inputs without throwing", () => {
     const { displayPlayers, displayNPCs } = deriveDisplayMaps(null, 5);
     expect(displayPlayers).toEqual({});
     expect(displayNPCs).toEqual({});
+  });
+
+  it("creates fresh entries when no previous display coordinates are available", () => {
+    const players = { alpha: { id: "alpha", x: 10, y: 20 } };
+    const npcs = { goblin: { id: "goblin", x: 30, y: 40 } };
+
+    const { displayPlayers, displayNPCs } = deriveDisplayMaps(players, npcs, {
+      alpha: { x: NaN, y: 0 },
+    });
+
+    expect(displayPlayers.alpha).toEqual({ x: 10, y: 20 });
+    expect(displayNPCs.goblin).toEqual({ x: 30, y: 40 });
   });
 });
 

--- a/client/network.js
+++ b/client/network.js
@@ -245,16 +245,39 @@ export function applyStateSnapshot(prev, payload) {
   return result;
 }
 
-export function deriveDisplayMaps(players, npcs) {
+export function deriveDisplayMaps(
+  players,
+  npcs,
+  previousDisplayPlayers = {},
+  previousDisplayNpcs = {},
+) {
   const normalizedPlayers = players && typeof players === "object" ? players : {};
   const normalizedNpcs = npcs && typeof npcs === "object" ? npcs : {};
+  const prevPlayers =
+    previousDisplayPlayers && typeof previousDisplayPlayers === "object"
+      ? previousDisplayPlayers
+      : {};
+  const prevNpcs =
+    previousDisplayNpcs && typeof previousDisplayNpcs === "object"
+      ? previousDisplayNpcs
+      : {};
 
   const displayPlayers = {};
   for (const player of Object.values(normalizedPlayers)) {
     if (!player || typeof player.id !== "string") {
       continue;
     }
-    displayPlayers[player.id] = { x: player.x, y: player.y };
+    const prev = prevPlayers[player.id];
+    if (
+      prev &&
+      typeof prev === "object" &&
+      Number.isFinite(prev.x) &&
+      Number.isFinite(prev.y)
+    ) {
+      displayPlayers[player.id] = prev;
+    } else {
+      displayPlayers[player.id] = { x: player.x, y: player.y };
+    }
   }
 
   const displayNPCs = {};
@@ -262,7 +285,17 @@ export function deriveDisplayMaps(players, npcs) {
     if (!npc || typeof npc.id !== "string") {
       continue;
     }
-    displayNPCs[npc.id] = { x: npc.x, y: npc.y };
+    const prev = prevNpcs[npc.id];
+    if (
+      prev &&
+      typeof prev === "object" &&
+      Number.isFinite(prev.x) &&
+      Number.isFinite(prev.y)
+    ) {
+      displayNPCs[npc.id] = prev;
+    } else {
+      displayNPCs[npc.id] = { x: npc.x, y: npc.y };
+    }
   }
 
   return { displayPlayers, displayNPCs };
@@ -538,6 +571,8 @@ export function connectEvents(store) {
         const { displayPlayers, displayNPCs } = deriveDisplayMaps(
           store.players,
           store.npcs,
+          store.displayPlayers,
+          store.displayNPCs,
         );
         store.displayPlayers = displayPlayers;
         store.displayNPCs = displayNPCs;


### PR DESCRIPTION
## Summary
- reuse existing display player and NPC positions when processing authoritative snapshots so lerp animation remains smooth
- extend network tests to cover display map reuse and fallback cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e65f0c0e88832f888535a8c526a1c5