### PR TITLE
Add tick counter to state messages

### DIFF
--- a/client/__tests__/network.test.js
+++ b/client/__tests__/network.test.js
@@ -329,6 +329,15 @@ describe("applyStateSnapshot", () => {
     expect(result.hasLocalPlayer).toBe(false);
     expect(result.currentFacing).toBeUndefined();
   });
+
+  it("applies tick from state", () => {
+    const result = applyStateSnapshot({ playerId: "local", lastTick: 7 }, {
+      players: [],
+      t: 42,
+    });
+
+    expect(result.lastTick).toBe(42);
+  });
 });
 
 describe("deriveDisplayMaps", () => {

--- a/client/main.js
+++ b/client/main.js
@@ -175,6 +175,7 @@ const store = {
   messagesSent: 0,
   bytesSent: 0,
   lastPathRequestAt: null,
+  lastTick: null,
   effects: [],
   pendingEffectTriggers: [],
   processedEffectTriggerIds: new Set(),

--- a/docs/client.md
+++ b/docs/client.md
@@ -15,7 +15,7 @@ The client is a lightweight ES module bundle served directly from the Go server.
 `main.js` creates a plain object (`store`) shared across modules. Key fields:
 - DOM references (canvas, status text, diagnostics elements).
 - Simulation constants (`TILE_SIZE`, `PLAYER_SIZE`, etc.).
-- Connection state (`socket`, `playerId`, heartbeat timestamps).
+- Connection state (`socket`, `playerId`, heartbeat timestamps, last authoritative tick).
 - Player dictionaries: `players` (authoritative) and `displayPlayers` (interpolated positions).
 - NPC dictionaries: `npcs` mirrors neutral enemies from the server, `displayNPCs` lerps their positions for rendering.
 - Arrays for `obstacles` and `effects` mirrored from server payloads.
@@ -32,7 +32,7 @@ The client is a lightweight ES module bundle served directly from the Go server.
 5. `connectEvents(store)` sets up WebSocket callbacks and kicks off the heartbeat loop.
 
 ## Networking Details
-- **State updates:** The server emits `state` messages containing players, NPCs, obstacles, effects, fire-and-forget `effectTriggers`, and `serverTime`. The client overwrites `store.players`, `store.npcs`, merges the display caches, queues effect triggers, and keeps diagnostics fresh.
+- **State updates:** The server emits `state` messages containing players, NPCs, obstacles, effects, fire-and-forget `effectTriggers`, the current tick (`t`), and `serverTime`. The client overwrites `store.players`, `store.npcs`, merges the display caches, queues effect triggers, stores `lastTick`, and keeps diagnostics fresh.
 - **Intents:** `sendCurrentIntent` serializes `{ type: "input", dx, dy, facing }` whenever movement or facing changes.
 - **Path navigation:** `sendMoveTo` sends `{ type: "path", x, y }` for click-to-move requests while `sendCancelPath` clears the server-driven route when WASD input resumes.
 - **Actions:** `sendAction` is used by `input.js` for melee and fireball triggers.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -22,7 +22,7 @@ If the socket drops the client tears down local state and re-runs the join flow 
 
 | Type | Description |
 | --- | --- |
-| `state` | Primary snapshot broadcast. Includes `players`, `npcs`, `obstacles`, `effects`, optional `effectTriggers`, optional `groundItems`, the `serverTime` of emission, and the current world configuration. Sent on every tick and immediately after subscribe/reset events. 【F:server/messages.go†L14-L24】【F:server/hub.go†L525-L567】 |
+| `state` | Primary snapshot broadcast. Includes `players`, `npcs`, `obstacles`, `effects`, optional `effectTriggers`, optional `groundItems`, the current tick (`t`), the `serverTime` of emission, and the world configuration. Sent on every tick and immediately after subscribe/reset events. 【F:server/messages.go†L14-L25】【F:server/hub.go†L547-L581】 |
 | `heartbeat` | Reply to client heartbeats containing `serverTime`, the echoed `clientTime`, and the computed `rtt` (milliseconds). 【F:server/messages.go†L40-L45】【F:server/main.go†L276-L315】 |
 | `console_ack` | Response for debug console commands with `status`, optional `reason`, the affected quantity, and the target ground stack ID when relevant. Triggered by `drop_gold` / `pickup_gold`. 【F:server/messages.go†L31-L38】【F:server/hub.go†L312-L444】 |
 

--- a/server/main.go
+++ b/server/main.go
@@ -215,19 +215,7 @@ func main() {
 			return
 		}
 
-		cfg := hub.CurrentConfig()
-
-		initial := stateMessage{
-			Type:        "state",
-			Players:     snapshotPlayers,
-			NPCs:        snapshotNPCs,
-			Obstacles:   append([]Obstacle(nil), hub.world.obstacles...),
-			Effects:     snapshotEffects,
-			GroundItems: snapshotGroundItems,
-			ServerTime:  time.Now().UnixMilli(),
-			Config:      cfg,
-		}
-		data, err := json.Marshal(initial)
+		data, err := hub.marshalState(snapshotPlayers, snapshotNPCs, snapshotEffects, nil, snapshotGroundItems)
 		if err != nil {
 			stdlog.Printf("failed to marshal initial state for %s: %v", playerID, err)
 			players, npcs, effects := hub.Disconnect(playerID)

--- a/server/messages.go
+++ b/server/messages.go
@@ -19,6 +19,7 @@ type stateMessage struct {
 	Effects        []Effect        `json:"effects"`
 	EffectTriggers []EffectTrigger `json:"effectTriggers,omitempty"`
 	GroundItems    []GroundItem    `json:"groundItems,omitempty"`
+	Tick           uint64          `json:"t"`
 	ServerTime     int64           `json:"serverTime"`
 	Config         worldConfig     `json:"config"`
 }

--- a/server/messages_test.go
+++ b/server/messages_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+)
+
+func TestStateMessage_ContainsTick(t *testing.T) {
+	hub := newHub()
+	hub.advance(time.Now(), 1.0/float64(tickRate))
+
+	data, err := hub.marshalState(nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("marshalState returned error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+
+	tickValue, ok := payload["t"]
+	if !ok {
+		t.Fatalf("expected payload to include tick field")
+	}
+
+	tickNumber, ok := tickValue.(float64)
+	if !ok {
+		t.Fatalf("expected tick to decode as number, got %T", tickValue)
+	}
+	if tickNumber < 0 {
+		t.Fatalf("expected non-negative tick, got %f", tickNumber)
+	}
+	if math.Mod(tickNumber, 1) != 0 {
+		t.Fatalf("expected tick to be integral, got %f", tickNumber)
+	}
+}
+
+func TestTickMonotonicity_AcrossBroadcasts(t *testing.T) {
+	hub := newHub()
+	dt := 1.0 / float64(tickRate)
+
+	ticks := make([]uint64, 0, 3)
+	for i := 0; i < 3; i++ {
+		hub.advance(time.Now(), dt)
+
+		data, err := hub.marshalState(nil, nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("marshalState returned error: %v", err)
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal(data, &payload); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+
+		value, ok := payload["t"]
+		if !ok {
+			t.Fatalf("payload missing tick field")
+		}
+		tickNumber, ok := value.(float64)
+		if !ok {
+			t.Fatalf("expected tick to decode as number, got %T", value)
+		}
+		if math.Mod(tickNumber, 1) != 0 {
+			t.Fatalf("expected tick to be integral, got %f", tickNumber)
+		}
+		ticks = append(ticks, uint64(tickNumber))
+	}
+
+	if len(ticks) != 3 {
+		t.Fatalf("expected to capture 3 ticks, got %d", len(ticks))
+	}
+
+	for i := 1; i < len(ticks); i++ {
+		if ticks[i] != ticks[i-1]+1 {
+			t.Fatalf("expected ticks to increase by 1, got %d then %d", ticks[i-1], ticks[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- include the current simulation tick in server state payloads and reuse a marshal helper for initial broadcasts
- persist the latest tick on the client store while normalizing snapshots and add coverage for the new field
- document the new tick metadata in the networking and client guides

## Testing
- go test ./...
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e683665944832f92d3df9060f93c30